### PR TITLE
SDR-768: Add configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "source/" directory with Sphinx
+sphinx:
+  configuration: source/conf.py
+  # Fail on all warnings to avoid broken references
+  fail_on_warning: true
+
+# Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+recommonmark
+sphinx_rtd_theme


### PR DESCRIPTION
Readthedocs projects are required to have a configuarion file, see: [this blog](https://blog.readthedocs.com/migrate-configuration-v2/).